### PR TITLE
add a line break after finishing logging

### DIFF
--- a/build.go
+++ b/build.go
@@ -13,6 +13,8 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 		command := "tini -g -- yarn start"
 		logger.Subprocess(command)
 
+		logger.Break()
+
 		return packit.BuildResult{
 			Plan: packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{},

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
   id = "paketo-buildpacks/yarn-start"
-  name = "Yarn-Start Buildpack"
+  name = "Paketo Yarn Start Buildpack"
   homepage = "https://github.com/paketo-buildpacks/yarn-start"
 
 [[stacks]]

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -76,6 +76,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Writing start command",
 				`    tini -g -- yarn start`,
+				"",
 			))
 
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort()))


### PR DESCRIPTION
- also rename to Paketo Yarn Start

Signed-off-by: Forest Eckhardt <feckhardt@vmware.com>