### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -62,6 +62,7 @@ func Build(pathParser PathParser, logger scribe.Logger) packit.BuildFunc {
 			{
 				Type:    "web",
 				Command: command,
+				Default: true,
 			},
 		}
 
@@ -83,6 +84,7 @@ func Build(pathParser PathParser, logger scribe.Logger) packit.BuildFunc {
 						fmt.Sprintf("--ignore %s", filepath.Join(context.WorkingDir, projectPath, "node_modules")),
 						fmt.Sprintf(`"%s"`, command),
 					}, " "),
+					Default: true,
 				},
 				{
 					Type:    "no-reload",
@@ -98,9 +100,6 @@ func Build(pathParser PathParser, logger scribe.Logger) packit.BuildFunc {
 		logger.Break()
 
 		return packit.BuildResult{
-			Plan: packit.BuildpackPlan{
-				Entries: []packit.BuildpackPlanEntry{},
-			},
 			Launch: packit.LaunchMetadata{
 				Processes: processes,
 			},

--- a/build_test.go
+++ b/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,23 +33,23 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.Mkdir(filepath.Join(workingDir, "some-project-dir"), os.ModePerm)).To(Succeed())
-		err = ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+		err = os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 			"scripts": {
 				"prestart": "some-prestart-command",
 				"start": "some-start-command",
 				"poststart": "some-poststart-command"
 			}
-		}`), 0644)
+		}`), 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		buffer = bytes.NewBuffer(nil)
@@ -85,14 +84,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result).To(Equal(packit.BuildResult{
-			Plan: packit.BuildpackPlan{
-				Entries: []packit.BuildpackPlanEntry{},
-			},
 			Launch: packit.LaunchMetadata{
 				Processes: []packit.Process{
 					{
 						Type:    "web",
 						Command: "cd some-project-dir && some-prestart-command && some-start-command && some-poststart-command",
+						Default: true,
 					},
 				},
 			},
@@ -137,6 +134,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						fmt.Sprintf("--ignore %s/some-project-dir/node_modules", workingDir),
 						`"cd some-project-dir && some-prestart-command && some-start-command && some-poststart-command"`,
 					}, " "),
+					Default: true,
 				},
 				{
 					Type:    "no-reload",
@@ -149,12 +147,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the package.json does not include a prestart command", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"start": "some-start-command",
 					"poststart": "some-poststart-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -175,14 +173,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{},
-				},
 				Launch: packit.LaunchMetadata{
 					Processes: []packit.Process{
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-start-command && some-poststart-command",
+							Default: true,
 						},
 					}},
 			}))
@@ -191,12 +187,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the package.json does not include a poststart command", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"prestart": "some-prestart-command",
 					"start": "some-start-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -217,14 +213,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{},
-				},
 				Launch: packit.LaunchMetadata{
 					Processes: []packit.Process{
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-prestart-command && some-start-command",
+							Default: true,
 						},
 					},
 				},
@@ -234,12 +228,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the package.json does not include a start command", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
+			err := os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte(`{
 				"scripts": {
 					"prestart": "some-prestart-command",
 					"poststart": "some-poststart-command"
 				}
-			}`), 0644)
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -260,14 +254,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{},
-				},
 				Launch: packit.LaunchMetadata{
 					Processes: []packit.Process{
 						{
 							Type:    "web",
 							Command: "cd some-project-dir && some-prestart-command && node server.js && some-poststart-command",
+							Default: true,
 						},
 					},
 				},
@@ -278,13 +270,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("when the project-path env var is not set", func() {
 		it.Before(func() {
 			pathParser.GetCall.Returns.ProjectPath = ""
-			err := ioutil.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
-			"scripts": {
-				"prestart": "some-prestart-command",
-				"start": "some-start-command",
-				"poststart": "some-poststart-command"
-			}
-		}`), 0644)
+			err := os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
+				"scripts": {
+					"prestart": "some-prestart-command",
+					"start": "some-start-command",
+					"poststart": "some-poststart-command"
+				}
+			}`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -309,14 +301,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{},
-				},
 				Launch: packit.LaunchMetadata{
 					Processes: []packit.Process{
 						{
 							Type:    "web",
 							Command: "some-prestart-command && some-start-command && some-poststart-command",
+							Default: true,
 						},
 					},
 				},
@@ -329,6 +319,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			it.Before(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, "some-project-dir", "package.json"))).To(Succeed())
 			})
+
 			it("fails with the appropriate error", func() {
 				_, err := build(packit.BuildContext{
 					WorkingDir: workingDir,
@@ -349,8 +340,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when package.json is malformed", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte("%%%"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "some-project-dir", "package.json"), []byte("%%%"), os.ModePerm)).To(Succeed())
 			})
+
 			it("fails with the appropriate error", func() {
 				_, err := build(packit.BuildContext{
 					WorkingDir: workingDir,

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/yarn-start"

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,7 +2,6 @@ package yarnstart_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Mkdir(filepath.Join(workingDir, "custom"), os.ModePerm)).To(Succeed())
 
@@ -42,8 +41,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is a yarn.lock", func() {
 		it.Before(func() {
-			Expect(ioutil.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0600)).To(Succeed())
 		})
+
 		it("detects", func() {
 			result, err := detect(packit.DetectContext{
 				WorkingDir: workingDir,
@@ -161,7 +161,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		context("when BP_LIVE_RELOAD_ENABLED is set to an invalid value", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0600)).To(Succeed())
 				os.Setenv("BP_LIVE_RELOAD_ENABLED", "not-a-bool")
 			})
 

--- a/integration/custom_start_cmd_test.go
+++ b/integration/custom_start_cmd_test.go
@@ -2,8 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,21 +81,12 @@ func testCustomStartCmd(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Hello, World!"))
-
-			cLogs := func() fmt.Stringer {
+			cLogs := func() string {
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
-				return containerLogs
+				return containerLogs.String()
 			}
 
 			Eventually(cLogs).Should(ContainSubstring("prestart"))
@@ -142,21 +131,12 @@ func testCustomStartCmd(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 
-				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
-
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-				content, err := ioutil.ReadAll(response.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(ContainSubstring("Hello, World!"))
-
-				cLogs := func() fmt.Stringer {
+				cLogs := func() string {
 					containerLogs, err := docker.Container.Logs.Execute(container.ID)
 					Expect(err).NotTo(HaveOccurred())
-					return containerLogs
+					return containerLogs.String()
 				}
 
 				Eventually(cLogs).Should(ContainSubstring("prestart"))

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -2,8 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,16 +79,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Hello, World!"))
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 		})
 
 		context("when BP_LIVE_RELOAD_ENABLED=true during the build", func() {
@@ -131,16 +120,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(container).Should(BeAvailable())
-
-				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
-
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-				content, err := ioutil.ReadAll(response.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(ContainSubstring("Hello, World!"))
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 			})
 		})
 	})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -46,6 +46,7 @@ var settings struct {
 
 func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
+	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	root, err := filepath.Abs("./..")
 	Expect(err).ToNot(HaveOccurred())
@@ -85,8 +86,6 @@ func TestIntegration(t *testing.T) {
 	settings.Buildpacks.Watchexec.Online, err = buildpackStore.Get.
 		Execute(settings.Config.Watchexec)
 	Expect(err).NotTo(HaveOccurred())
-
-	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("CustomStartCmd", testCustomStartCmd)

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -2,8 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,21 +82,12 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Hello, World!"))
-
-			cLogs := func() fmt.Stringer {
+			cLogs := func() string {
 				containerLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
-				return containerLogs
+				return containerLogs.String()
 			}
 
 			Eventually(cLogs).Should(ContainSubstring("prehello"))
@@ -144,21 +133,12 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("Hello, World!")))
 
-				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
-
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-				content, err := ioutil.ReadAll(response.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(ContainSubstring("Hello, World!"))
-
-				cLogs := func() fmt.Stringer {
+				cLogs := func() string {
 					containerLogs, err := docker.Container.Logs.Execute(container.ID)
 					Expect(err).NotTo(HaveOccurred())
-					return containerLogs
+					return containerLogs.String()
 				}
 
 				Eventually(cLogs).Should(ContainSubstring("prehello"))

--- a/integration/workspaces_test.go
+++ b/integration/workspaces_test.go
@@ -2,8 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,17 +79,8 @@ func testWorkspaces(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
-
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			content, err := ioutil.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("Package A value 1"))
-			Expect(string(content)).To(ContainSubstring("Package A value 2"))
+			Eventually(container).Should(Serve(ContainSubstring("Package A value 1")))
+			Eventually(container).Should(Serve(ContainSubstring("Package A value 2")))
 		})
 	})
 }

--- a/project_path_parser_test.go
+++ b/project_path_parser_test.go
@@ -2,7 +2,6 @@ package yarnstart_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ func testProjectPathParser(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 		projectDir = filepath.Join(workingDir, "custom", "path")
 		err = os.MkdirAll(projectDir, os.ModePerm)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
