### PR TITLE
Fixes detection of yarn-start buildpack

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,9 +1,7 @@
 package yarnstart
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -14,27 +12,16 @@ func Build(pathParser PathParser, logger scribe.Emitter) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
-		var pkg struct {
-			Scripts struct {
-				PostStart string `json:"poststart"`
-				PreStart  string `json:"prestart"`
-				Start     string `json:"start"`
-			} `json:"scripts"`
-		}
-
 		projectPath, err := pathParser.Get(context.WorkingDir)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}
 
-		file, err := os.Open(filepath.Join(projectPath, "package.json"))
-		if err != nil {
-			return packit.BuildResult{}, fmt.Errorf("Unable to open package.json: %w", err)
-		}
+		var pkg *PackageJson
 
-		err = json.NewDecoder(file).Decode(&pkg)
+		pkg, err = NewPackageJsonFromPath(filepath.Join(projectPath, "package.json"))
 		if err != nil {
-			return packit.BuildResult{}, fmt.Errorf("Unable to decode package.json: %w", err)
+			return packit.BuildResult{}, err
 		}
 
 		command := "node"

--- a/build_test.go
+++ b/build_test.go
@@ -367,7 +367,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					Layers: packit.Layers{Path: layersDir},
 				})
-				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Unable to open package.json: open %s", filepath.Join(workingDir, "some-project-dir", "package.json")))))
+				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("unable to open package.json: open %s", filepath.Join(workingDir, "some-project-dir", "package.json")))))
 			})
 		})
 
@@ -390,7 +390,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					Layers: packit.Layers{Path: layersDir},
 				})
-				Expect(err).To(MatchError(ContainSubstring("Unable to decode package.json: invalid character")))
+				Expect(err).To(MatchError(ContainSubstring("unable to decode package.json: invalid character")))
 			})
 		})
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	json "encoding/json"
 )
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
@@ -39,8 +40,17 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
-	context("when there is a yarn.lock", func() {
+	context("when there is a yarn.lock and a start script", func() {
 		it.Before(func() {
+			content := yarnstart.PackageJson{Scripts: yarnstart.PackageScripts{
+				Start: "node server.js",
+			}}
+
+			bytes, err := json.Marshal(content)
+			Expect(err).To(BeNil())
+
+			Expect(os.WriteFile(filepath.Join(workingDir, "custom", "package.json"), bytes, 0600)).To(Succeed())
+
 			Expect(os.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0600)).To(Succeed())
 		})
 
@@ -161,6 +171,16 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		context("when BP_LIVE_RELOAD_ENABLED is set to an invalid value", func() {
 			it.Before(func() {
+				content := yarnstart.PackageJson{Scripts: yarnstart.PackageScripts{
+					Start: "node server.js",
+				}}
+
+				bytes, err := json.Marshal(content)
+				Expect(err).To(BeNil())
+
+				Expect(os.WriteFile(filepath.Join(workingDir, "custom", "package.json"), bytes, 0600)).To(Succeed())
+
+
 				Expect(os.WriteFile(filepath.Join(workingDir, "custom", "yarn.lock"), nil, 0600)).To(Succeed())
 				os.Setenv("BP_LIVE_RELOAD_ENABLED", "not-a-bool")
 			})

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitGoBuild(t *testing.T) {
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("ProjectPathParser", testProjectPathParser)
+	suite("PackageJsonParser", testPackageJsonParser)
 	suite.Run(t)
 }

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -67,7 +67,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
-				"    web (default): node /workspace/server.js",
+				"    web (default): bash -c node server.js",
 				"",
 			))
 
@@ -107,8 +107,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 					"  Assigning launch processes:",
-					`    web (default): watchexec --restart --shell none --watch /workspace --ignore /workspace/package.json --ignore /workspace/yarn.lock --ignore /workspace/node_modules -- node /workspace/server.js`,
-					"    no-reload:     node /workspace/server.js",
+					`    web (default): watchexec --restart --shell none --watch /workspace --ignore /workspace/package.json --ignore /workspace/yarn.lock --ignore /workspace/node_modules -- bash -c node server.js`,
+					"    no-reload:     bash -c node server.js",
 					"",
 				))
 

--- a/integration/graceful_shutdown_test.go
+++ b/integration/graceful_shutdown_test.go
@@ -77,7 +77,7 @@ func testGracefulShutdown(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
-				"    web (default): node /workspace/server.js",
+				"    web (default): bash -c node server.js",
 				"",
 			))
 

--- a/integration/testdata/default_app/package.json
+++ b/integration/testdata/default_app/package.json
@@ -11,6 +11,7 @@
     "url": ""
   },
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "version": "0.0.0"

--- a/integration/testdata/graceful_shutdown_app/package.json
+++ b/integration/testdata/graceful_shutdown_app/package.json
@@ -14,6 +14,7 @@
     "url": ""
   },
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "version": "0.0.0"

--- a/package_json_parser.go
+++ b/package_json_parser.go
@@ -1,0 +1,38 @@
+package yarnstart
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type PackageScripts struct {
+	PostStart string `json:"poststart"`
+	PreStart  string `json:"prestart"`
+	Start     string `json:"start"`
+}
+
+type PackageJson struct {
+	Scripts PackageScripts `json:"scripts"`
+}
+
+func NewPackageJsonFromPath(filelocation string) (*PackageJson, error) {
+	file, err := os.Open(filelocation)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open package.json: %w", err)
+	}
+	defer file.Close()
+
+	var pkg PackageJson
+
+	err = json.NewDecoder(file).Decode(&pkg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode package.json: invalid character")
+	}
+
+	return &pkg, nil
+}
+
+func (pkg PackageJson) hasStartCommand() bool {
+	return pkg.Scripts.Start != ""
+}

--- a/package_json_parser_test.go
+++ b/package_json_parser_test.go
@@ -1,0 +1,81 @@
+package yarnstart_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	yarnstart "github.com/paketo-buildpacks/yarn-start"
+	"github.com/sclevine/spec"
+)
+
+func testPackageJsonParser(t *testing.T, context spec.G, it spec.S) {
+	Expect := NewWithT(t).Expect
+
+	context("when parsing a valid package.json with start scripts", func() {
+		var packageLocation string
+		var workingDir string
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			content := `{
+				"scripts": {
+					"poststart": "echo \"poststart\"",
+					"prestart": "echo \"prestart\"",
+					"start": "echo \"start\" && node server.js"
+				}
+			  },
+			`
+
+			packageLocation = filepath.Join(workingDir, "package.json")
+			Expect(os.WriteFile(packageLocation, []byte(content), 0600)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+		})
+
+		it("successfully extracts the scripts information", func() {
+			pkg, err := yarnstart.NewPackageJsonFromPath(packageLocation)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pkg.Scripts.Start).To(ContainSubstring(`echo "start" && node server.js`))
+			Expect(pkg.Scripts.PreStart).To(Equal(`echo "prestart"`))
+			Expect(pkg.Scripts.PostStart).To(Equal(`echo "poststart"`))
+		})
+	})
+
+	context("when the package.json is not a valid json file", func() {
+		var packageLocation string
+		var workingDir string
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			packageLocation = filepath.Join(workingDir, "package.json")
+			Expect(os.WriteFile(packageLocation, nil, 0600)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+		})
+
+		it("fails parsing", func() {
+			_, err := yarnstart.NewPackageJsonFromPath(packageLocation)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	context("when the path to package.json is invalid", func() {
+		it("fails parsing", func() {
+			_, err := yarnstart.NewPackageJsonFromPath("/tmp/non-existent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}


### PR DESCRIPTION
## Summary
The changes have the effect that this buildpack no longer detects builds without a proper start script in the project's package-json.

## Use Cases
Similar to https://github.com/paketo-buildpacks/npm-start/issues/176

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary. -> refactored 
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).