### PR TITLE
Fix for fetching proper image on multiarch buildpacks

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -7,5 +7,5 @@
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "yarn": "github.com/paketo-buildpacks/yarn",
   "yarn-install": "github.com/paketo-buildpacks/yarn-install",
-  "watchexec": "github.com/paketo-buildpacks/watchexec"
+  "watchexec": "index.docker.io/paketobuildpacks/watchexec"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR changes the image being fetched during integrations tests. Specifically, instead of using buildpackstore to package the buildpacks, pulls the packaged image from the registry. That way, the architecture of the buildpack is properly resolved, compared to using buildpackstore which cant resolve it properly at the moment.

## Use Cases
<!-- An explanation of the use cases your change enables -->

CI/CD is failing at the moment as buildpackstore doesnt create the multiarch watchexec package properly. This PR fixes that by pulling the proper image instead of constructing it with buildpackstore.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
