### PR TITLE
Reverting the change of fetching watchexec from registry instead of building it.

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -7,5 +7,5 @@
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "yarn": "github.com/paketo-buildpacks/yarn",
   "yarn-install": "github.com/paketo-buildpacks/yarn-install",
-  "watchexec": "index.docker.io/paketobuildpacks/watchexec"
+  "watchexec": "github.com/paketo-buildpacks/watchexec"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/occam"
+	"github.com/paketo-buildpacks/occam/packagers"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 )
@@ -51,8 +52,6 @@ var settings struct {
 }
 
 func TestIntegration(t *testing.T) {
-	var docker = occam.NewDocker()
-
 	Expect := NewWithT(t).Expect
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
@@ -85,6 +84,8 @@ func TestIntegration(t *testing.T) {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
+	libpakBuildpackStore := occam.NewBuildpackStore().WithPackager(packagers.NewLibpak())
+
 	settings.Buildpacks.YarnStart.Online, err = buildpackStore.Get.
 		WithVersion("1.2.3").
 		Execute(root)
@@ -102,11 +103,9 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.YarnInstall)
 	Expect(err).NotTo(HaveOccurred())
 
-	settings.Buildpacks.Watchexec.Online = settings.Config.Watchexec
-	err = docker.Pull.Execute(settings.Buildpacks.Watchexec.Online)
-	if err != nil {
-		t.Fatalf("Failed to pull %s: %s", settings.Buildpacks.Watchexec.Online, err)
-	}
+	settings.Buildpacks.Watchexec.Online, err = libpakBuildpackStore.Get.
+		Execute(settings.Config.Watchexec)
+	Expect(err).NotTo(HaveOccurred())
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("CustomStartCmd", testCustomStartCmd)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR reverts the change of this PR https://github.com/paketo-buildpacks/yarn-start/pull/462  which was fetching watchexec from the registry instead of building it. This change had to be made in the past as pack CLI could not properly support building buildpacks with `--target` flag. On later versions of the `pack`, this bug has been fixed, as seen on the changelog https://github.com/buildpacks/pack/releases/tag/v0.34.0 , so now watchexec can be properly builded.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
